### PR TITLE
Feature/update farady version dependency

### DIFF
--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -175,7 +175,7 @@ module Parse
         defaults[:master_key] = ENV['PARSE_MASTER_API_KEY']
       end
 
-      Client.new(defaults, &blk)
+      @@client = Client.new(defaults, &blk)
     end
 
     # DEPRECATED: Please use create instead.

--- a/lib/parse/version.rb
+++ b/lib/parse/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Parse
-  VERSION = '1.0.0.alpha1'
+  VERSION = '1.0.1.alpha1'
 end

--- a/parse-ruby-client.gemspec
+++ b/parse-ruby-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'faraday', '~> 0.9.2'
+  spec.add_dependency 'faraday', '~> 0.11.0'
   spec.add_dependency 'faraday_middleware', '~> 0.10.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
## Contexto y cambios generales técnicos
Dentro de la actualización a rails 6 de Lastmile surge el warning `gems/faraday-0.9.2/lib/faraday/request/retry.rb:30: warning: constant ::Fixnum is deprecated` Esa constante `FIxnum` se usa en la version de `faraday` de `parse-ruby-client`.
Por lo que se necesita actualizar la dependencia de `farady` 