### PR TITLE
update faraday version for ondemand engine

### DIFF
--- a/parse-ruby-client.gemspec
+++ b/parse-ruby-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'faraday', '~> 0.11.0'
+  spec.add_dependency 'faraday', '~> 0.17.3'
   spec.add_dependency 'faraday_middleware', '~> 0.10.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Se actualiza la version de `Faraday` a la version `0.17.3` para el uso del engine de `ondemand` en `lastmile`